### PR TITLE
Update pre.ssh_maxstartups_config.yml

### DIFF
--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.ssh_maxstartups_config.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.ssh_maxstartups_config.yml
@@ -16,7 +16,7 @@
   ## block start
 
   - name: Capture current SSH maxstartups value (third one)
-    shell: "/sbin/sshd -T | grep maxstartups | awk -F'[: ]' '{print $4}'"
+    shell: "sshd -T | grep maxstartups | awk -F'[: ]' '{print $4}'"
     changed_when: False
     check_mode: no
     register: cur_maxstartups_3
@@ -34,13 +34,13 @@
     - debug: msg="your current maxstartups value ({{cur_maxstartups_3.stdout}}) is smaller than the desired maxstartups value ({{maxstartups_val}})"
 
     - name: Capture current SSH maxstartups value (first one)
-      shell: "/sbin/sshd -T | grep maxstartups | awk -F'[: ]' '{print $2}'"
+      shell: "sshd -T | grep maxstartups | awk -F'[: ]' '{print $2}'"
       changed_when: False
       check_mode: no
       register: cur_maxstartups_1
 
     - name: Capture current SSH maxstartups value (second one)
-      shell: "/sbin/sshd -T | grep maxstartups | awk -F'[: ]' '{print $3}'"
+      shell: "sshd -T | grep maxstartups | awk -F'[: ]' '{print $3}'"
       changed_when: False
       check_mode: no
       register: cur_maxstartups_2
@@ -62,18 +62,18 @@
     - debug: var=sshd_config
 
     ##
-    ## Re-run /sbin/sshd -T to see if it executes successfully or complains,
+    ## Re-run sshd -T to see if it executes successfully or complains,
     ## in order to validate our change to sshd_config file did not break sshd settings
     ##
-    - name: Run /sbin/sshd -T to test for validity of /etc/ssh/sshd_config file after making our change
-      shell: "/sbin/sshd -T"
+    - name: Run sshd -T to test for validity of /etc/ssh/sshd_config file after making our change
+      shell: "sshd -T"
       changed_when: False
       check_mode: no
       register: sshd_validation_results
       ignore_errors: true
       when: sshd_config is defined
 
-    - name: Show results of /sbin/sshd -T execution (return code)
+    - name: Show results of sshd -T execution (return code)
       debug:
         msg:
           #- "{{sshd_validation_results.stdout_lines}}"
@@ -95,7 +95,7 @@
         msg:
           - "It seems that something went wrong with the file /etc/ssh/sshd_config"
           - "You should review the MaxStartups line, and correct it"
-          - "Do NOT restart the sshd service until the command '/sbin/sshd -T' returns a clean output"
+          - "Do NOT restart the sshd service until the command 'sshd -T' returns a clean output"
       when: sshd_validation_results.rc is defined
 
     when: cur_maxstartups_3 is defined and ((cur_maxstartups_3.stdout | int) < maxstartups_val|int)


### PR DESCRIPTION
Updated script to run sshd instead of /sbin/sshd. Changes tested on RHEL 6.7, 7, 7.2, 7.3, and 7.4, and Oracle Linux 6.7 and 7.2.