### PR TITLE
Replacing "java" package with "java-1.8.0-openjdk"

### DIFF
--- a/playbooks/pre-install-playbook/roles/virk.preinstall/defaults/main.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/defaults/main.yml
@@ -93,7 +93,7 @@ yum_cache_min_space_mb: 8000   ## how many MB of free space should be in /var/yu
 ## general packages that are mandatory for Viya to work
 
 yum_packages_general:
-  - java
+  - java-1.8.0-openjdk
   - numactl
   - libXp.x86_64
   - libXp.i686


### PR DESCRIPTION
Using "java" may install the IBM JRE, which is not supported.
Instead, you should use the Oracle JRE or OpenJDK. 
Particularly, this causes issues when building the playbook, if using that version of Java to build it.