### PR TITLE
Changing syntax in msg in assert tasks to be compatible with ansible 2.7

### DIFF
--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.cpu_check.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.cpu_check.yml
@@ -36,10 +36,10 @@
     assert:
       that:
         - (cpuinfo.stdout | int) >= (min_cores_num | int)
-      msg:
-        - "This server should have at least ({{min_cores_num}}) cores."
-        - "It only has {{(cpuinfo.stdout | int)}} core(s)."
-        - "Add --skip-tags skipcoresfail to bypass."
+      msg: |
+        This server should have at least ({{min_cores_num}}) cores.
+        It only has {{(cpuinfo.stdout | int)}} core(s).
+        Add --skip-tags skipcoresfail to bypass.
     tags:
       - skipifbelowspecs
       - skipcoresfail

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.hostname_length_check.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.hostname_length_check.yml
@@ -25,10 +25,10 @@
     assert:
       that:
         - (hostname_length.stdout | int) <= (max_hostname_length | int)
-      msg:
-        - "The hostname is too long."
-        - "Yours is {{hostname_length.stdout | int}} characters long. It should be {{max_hostname_length}} characters or less."
-        - "Add --skip-tags skipnamelengthfail to bypass"
+      msg: |
+        The hostname is too long.
+        Yours is {{hostname_length.stdout | int}} characters long. It should be {{max_hostname_length}} characters or less.
+        Add --skip-tags skipnamelengthfail to bypass.
     tags:
       - skipnamelengthfail
 
@@ -49,11 +49,11 @@
     assert:
       that:
         -  "'.' in (full_hostname.stdout)"
-      msg:
-        - "Your fully qualified hostname value ({{full_hostname.stdout}}) does not contain a dot."
-        - "So, it does not really look fully qualified."
-        - "This will likely make rabbitmq unhappy. (because it uses long-form names to communicate between members of the cluster)"
-        - "Add --skip-tags skipnamematchfail to bypass"
+      msg: |
+        Your fully qualified hostname value ({{full_hostname.stdout}}) does not contain a dot.
+        So, it does not really look fully qualified.
+        This will likely make rabbitmq unhappy. (because it uses long-form names to communicate between members of the cluster).
+        Add --skip-tags skipnamematchfail to bypass.
     tags:
       - skipnamematchfail
 

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.memory_check.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.memory_check.yml
@@ -27,10 +27,10 @@
     assert:
       that:
         - ( ansible_memory_mb.real.total | int ) >= ( min_mem_mb | int )
-      msg:
-        - "This server should have at least {{(min_mem_mb | int) / 1000}} GB of total memory."
-        - "It only has {{( ansible_memory_mb.real.total | int) / 1000}} GB."
-        - "Add --skip-tags skipmemfail to bypass"
+      msg: |
+        This server should have at least {{(min_mem_mb | int) / 1000}} GB of total memory.
+        It only has {{( ansible_memory_mb.real.total | int) / 1000}} GB.
+        Add --skip-tags skipmemfail to bypass.
     tags:
       - skipifbelowspecs
       - skipmemfail

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.network_and_bandwidth_check.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.network_and_bandwidth_check.yml
@@ -30,13 +30,12 @@
     assert:
       that:
         - (num_priv_ips.stdout | int) <= (max_num_priv_ips | int)
-      msg:
-        - "This server seems to have {{num_priv_ips.stdout|int}} IP addresses."
-        - "It should only have {{max_num_priv_ips|int}} at most."
-        - "This will require more work for Consul to successfully start."
-        - "Please read the Deployment guide and search for the reference to the following parameter:"
-        - "   consul_bind_adapter=   "
-        - "Add --skip-tags skipipsfail to suppress this failure and message."
+      msg: |
+        This server seems to have {{num_priv_ips.stdout|int}} IP addresses.
+        It should only have {{max_num_priv_ips|int}} at most.
+        This will require more work for Consul to successfully start.
+        Please read the Deployment guide and search for the reference to the following parameter: consul_bind_adapter=   
+        Add --skip-tags skipipsfail to suppress this failure and message.
     tags:
       - nics
       - privips

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.os_version_check.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.os_version_check.yml
@@ -16,11 +16,10 @@
       that:
         # the OS is redhat or SUSE
         - ansible_os_family == redhat_os_name or ansible_os_family == suse_os_name 
-      msg:
-        - "The OS of this server is not supported."
-        - "Viya requires {{redhat_os_name}} {{os_major_version_1}} or {{os_major_version_2}}, (at least {{os_major_minor_version_1}} or {{os_major_minor_version_2}} ) "
-        - "or {{suse_os_name}} at least version {{suse_os_major_minor_version}}"
-        - "You seem to have {{ansible_os_family}} {{ansible_distribution_version}}"
+      msg: |
+        The OS of this server is not supported.
+        Viya requires {{redhat_os_name}} {{os_major_version_1}} or {{os_major_version_2}}, (at least {{os_major_minor_version_1}} or {{os_major_minor_version_2}} ) or {{suse_os_name}} at least version {{suse_os_major_minor_version}}
+        You seem to have {{ansible_os_family}} {{ansible_distribution_version}}
 
   - name: Ensure that the Operating System version is supported when on RedHat (this includes Oracle Linux)
     assert:
@@ -37,10 +36,10 @@
           (ansible_distribution_major_version | version_compare(os_major_version_2, '==')
           and
           ansible_distribution_version | version_compare(os_major_minor_version_2, '>='))
-      msg:
-        - "The OS of this server is not supported."
-        - "Viya requires {{redhat_os_name}} {{os_major_version_1}} or {{os_major_version_2}}, (at least {{os_major_minor_version_1}} or {{os_major_minor_version_2}} ) "
-        - "You seem to have {{ansible_os_family}} {{ansible_distribution_version}}"
+      msg: |
+        The OS of this server is not supported.
+        Viya requires {{redhat_os_name}} {{os_major_version_1}} or {{os_major_version_2}}, (at least {{os_major_minor_version_1}} or {{os_major_minor_version_2}} )
+        You seem to have {{ansible_os_family}} {{ansible_distribution_version}}
     when: ansible_os_family == redhat_os_name
 
   - name: Ensure that the Operating System version is supported when on Suse
@@ -48,10 +47,10 @@
       that:
         # version is at least 12.2
         - ansible_distribution_version | version_compare(suse_os_major_minor_version, '>=')
-      msg:
-        - "The OS of this server is not supported."
-        - "Viya requires {{suse_os_name}} at least version {{suse_os_major_minor_version}}"
-        - "You seem to have {{ansible_os_family}} {{ansible_distribution_version}}"
+      msg: |
+        The OS of this server is not supported.
+        Viya requires {{suse_os_name}} at least version {{suse_os_major_minor_version}}
+        You seem to have {{ansible_os_family}} {{ansible_distribution_version}}
     when: ansible_os_family == suse_os_name
 
   tags:

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.ssh_maxstartups_config.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.ssh_maxstartups_config.yml
@@ -109,10 +109,10 @@
       assert:
         that:
           - sshd_validation_results.rc is defined and sshd_validation_results.rc == 0
-        msg:
-          - "It seems that something went wrong with the file /etc/ssh/sshd_config"
-          - "You should review the MaxStartups line, and correct it"
-          - "Do NOT restart the sshd service until the command 'sshd -T' returns a clean output"
+        msg: |
+          It seems that something went wrong with the file /etc/ssh/sshd_config.
+          You should review the MaxStartups line, and correct it.
+          Do NOT restart the sshd service until the command 'sshd -T' returns a clean output.
       when: sshd_validation_results.rc is defined
 
     when: cur_maxstartups_3 is defined and ((cur_maxstartups_3.stdout | int) < maxstartups_val|int)

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.storage_check.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.storage_check.yml
@@ -34,10 +34,10 @@
     assert:
       that:
         - item.stat.exists and (item.stat.isdir or item.stat.islnk)
-      msg:
-        - "The directory {{item.item.path}} does not exist on this server."
-        - "Edit the storage_list variable if this is a mistake."
-        - "Or add --skip-tags skipstoragefail to bypass"
+      msg: |
+        The directory {{item.item.path}} does not exist on this server.
+        Edit the storage_list variable if this is a mistake.
+        Or add --skip-tags skipstoragefail to bypass.
     with_items:
       - "{{directories_exists.results}}"
     tags:
@@ -58,11 +58,11 @@
     assert:
       that:
         - (item.stdout | int) >= (item.item.item.min_storage_mb | int)
-      msg:
-      - "The directory {{item.item.item.path}} only has {{(item.stdout | int) / 1000}} GB of free space."
-      - "It should have at least {{(item.item.item.min_storage_mb | int) / 1000}} GB."
-      - "Edit storage_list if this is a mistake."
-      - "Or add --skip-tags skipstoragefail to bypass"
+      msg: |
+        The directory {{item.item.item.path}} only has {{(item.stdout | int) / 1000}} GB of free space.
+        It should have at least {{(item.item.item.min_storage_mb | int) / 1000}} GB.
+        Edit the storage_list variable if this is a mistake.
+        Or add --skip-tags skipstoragefail to bypass.
     with_items:
       - "{{df_result.results}}"
     tags:

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.user_and_group_config.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.user_and_group_config.yml
@@ -40,14 +40,14 @@
     assert:
       that:
         - ( item.stdout == "" ) or (( item.stdout | int ) == ( item.item.gid | int))
-      msg:
-        - "We looked for the group '{{item.item.group}}'. (getent group {{item.item.group}})"
-        - "We found that this group already exists and has a GID of {{item.stdout}}"
-        - "In your variables file, you stated that group '{{item.item.group}}' should have a GID of '{{item.item.gid}}'"
-        - "Therefore, we are not making any changes. You can do one of the following:"
-        - " - Review the content of the 'custom_group_list' variable to make it match your existing group(s)"
-        - " - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts"
-        - " - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups"
+      msg: |
+        We looked for the group '{{item.item.group}}'. (getent group {{item.item.group}}).
+        We found that this group already exists and has a GID of {{item.stdout}}.
+        In your variables file, you stated that group '{{item.item.group}}' should have a GID of '{{item.item.gid}}'.
+        Therefore, we are not making any changes. You can do one of the following
+        - Review the content of the 'custom_group_list' variable to make it match your existing group(s).
+        - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts.
+        - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups.
     with_items:
       - "{{gather_gid.results}}"
     when: create_local_cas_and_sas_accounts == true
@@ -84,14 +84,14 @@
     assert:
       that:
         - ( item.stdout == "" ) or (( item.stdout ) == ( item.item.group ))
-      msg:
-        - "We looked for the GID '{{item.item.gid}}'. (getent group {{item.item.gid}})"
-        - "We found that this GID is already assigned but to the group '{{item.stdout}}'"
-        - "In your variables file, you stated that group '{{item.item.group}}' should have a GID of '{{item.item.gid}}', but it seems to already belong to group '{{item.stdout}}'"
-        - "Therefore, we are not making any changes. You can do one of the following:"
-        - " - Review the content of the 'custom_group_list' variable to make it match your existing group(s)"
-        - " - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts"
-        - " - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups"
+      msg: |
+        We looked for the GID '{{item.item.gid}}'. (getent group {{item.item.gid}}).
+        We found that this GID is already assigned but to the group '{{item.stdout}}'.
+        In your variables file, you stated that group '{{item.item.group}}' should have a GID of '{{item.item.gid}}', but it seems to already belong to group '{{item.stdout}}'.
+        Therefore, we are not making any changes. You can do one of the following
+        - Review the content of the 'custom_group_list' variable to make it match your existing group(s).
+        - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts.
+        - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups.
     with_items:
       - "{{gather_group.results}}"
     when: create_local_cas_and_sas_accounts == true
@@ -140,14 +140,14 @@
     assert:
       that:
         - ( item.stdout == "" ) or (( item.stdout | int ) == ( item.item.uid | int))
-      msg:
-        - "We looked for the user '{{item.item.name}}'. (getent passwd {{item.item.name}})"
-        - "We found that this user already exists and has a UID of {{item.stdout}}"
-        - "In your variables file, you stated that user '{{item.item.name}}' should have a UID of '{{item.item.uid}}'"
-        - "Therefore, we are not making any changes. You can do one of the following:"
-        - " - Review the content of the 'custom_user_list' variable to make it match your existing users(s)"
-        - " - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts"
-        - " - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups"
+      msg: |
+        We looked for the user '{{item.item.name}}'. (getent passwd {{item.item.name}}).
+        We found that this user already exists and has a UID of {{item.stdout}}.
+        In your variables file, you stated that user '{{item.item.name}}' should have a UID of '{{item.item.uid}}'.
+        Therefore, we are not making any changes. You can do one of the following.
+        - Review the content of the 'custom_user_list' variable to make it match your existing users(s).
+        - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts.
+        - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups.
     with_items:
       - "{{gather_uid.results}}"
     when: create_local_cas_and_sas_accounts == true
@@ -177,14 +177,14 @@
     assert:
       that:
         - ( item.stdout == "" ) or (( item.stdout ) == ( item.item.name ))
-      msg:
-        - "We looked for the UID '{{item.item.uid}}'. (getent group {{item.item.uid}})"
-        - "We found that this UID is already assigned but to the user '{{item.stdout}}'"
-        - "In your variables file, you stated that user '{{item.item.name}}' should have a UID of '{{item.item.uid}}', but it seems to already belong to '{{item.stdout}}'"
-        - "Therefore, we are not making any changes. You can do one of the following:"
-        - " - Review the content of the 'custom_user_list' variable to make it match your existing user(s)"
-        - " - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts"
-        - " - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups"
+      msg: |
+        We looked for the UID '{{item.item.uid}}'. (getent group {{item.item.uid}}).
+        We found that this UID is already assigned but to the user '{{item.stdout}}'.
+        In your variables file, you stated that user '{{item.item.name}}' should have a UID of '{{item.item.uid}}', but it seems to already belong to '{{item.stdout}}'.
+        Therefore, we are not making any changes. You can do one of the following.
+        - Review the content of the 'custom_user_list' variable to make it match your existing user(s).
+        - Add  -e 'create_local_cas_and_sas_accounts=false'   to the command so that it does not verify or create accounts.
+        - Add  --skip-tags user_and_group_config   to have ansible skip the entire section about users and groups".
     with_items:
       - "{{gather_name.results}}"
     when: create_local_cas_and_sas_accounts == true

--- a/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.yum_cache_config.yml
+++ b/playbooks/pre-install-playbook/roles/virk.preinstall/tasks/pre.yum_cache_config.yml
@@ -25,11 +25,11 @@
     assert:
       that:
         - var_cache_yum_actual.stdout | int > yum_cache_min_space_mb | int
-      msg:
-        - "There is only {{var_cache_yum_actual.stdout | int}} MB available for YUM cache."
-        - "You need at least {{yum_cache_min_space_mb}} MB"
-        - "Either add more space or set the yum_cache_yn to 0."
-        - "Add --skip-tags skipyumspacefail to bypass"
+      msg: |
+        There is only {{var_cache_yum_actual.stdout | int}} MB available for YUM cache.
+        You need at least {{yum_cache_min_space_mb}} MB.
+        Either add more space or set the yum_cache_yn to 0.
+        Add --skip-tags skipyumspacefail to bypass.
     tags:
       - skipifbelowspecs
       - skipyumspacefail

--- a/virk-release
+++ b/virk-release
@@ -2,5 +2,5 @@
 # VIRK Repo release information file
 #
 Version : 3.4-DEV
-Date    : 05-03-2018
+Date    : 10-26-2018
 Branch  : viya-3.4-dev


### PR DESCRIPTION
With ansible 2.7, in an assert, the msg cannot be a list. 
I therefore converted the syntax from 
```
msg:
  - "first line"
  - "second line"
```
to 
```
msg: | 
  first line.
  second line.
```
the output is not as pretty, but if I want this to work with ansible 2.7, I had no choice. 